### PR TITLE
- Create diffusion inpaint method inside diffusion_based.py module

### DIFF
--- a/manipulate_depthmap/examples/depthmap_filling.py
+++ b/manipulate_depthmap/examples/depthmap_filling.py
@@ -3,12 +3,14 @@ from pathlib import Path
 import cv2
 import pandas as pd
 
-from manipulate_depthmap.hole_filling_methods.inpainting_methods import \
-    InpaintingMethod
+from manipulate_depthmap.hole_filling_methods.inpaint_methods.patch_based import \
+    PatchInpaintMethod
+from manipulate_depthmap.hole_filling_methods.inpaint_methods.diffusion_based import \
+    DiffusionInpaintMethod
 from manipulate_depthmap.hole_filling_methods.interpolation_methods import \
     InterpolationMethod
 from manipulate_depthmap.utilities.plottings import \
-    plot_depth_map_from_img_dataframe
+    plot_depth_map_from_img_dataframe, compare_methods_metrics
 
 image_name = "Rosemary"
 
@@ -32,12 +34,18 @@ filled_depth_map_interpol = interpolation_method.fill_holes(depth_map=sparse_map
 interpolation_method.calculate_metrics(depth_map=filled_depth_map_interpol, ground_truth=ground_truth)
 plot_depth_map_from_img_dataframe(filled_depth_map_interpol)
 
-# Filling through inpainting
+# Filling through patch inpainting
 inpaint_radius = 2
-inpainting_method = InpaintingMethod(inpaint_radius=inpaint_radius)
-filled_depth_map_inpaint = inpainting_method.fill_holes(depth_map=sparse_map)
-inpainting_method.calculate_metrics(depth_map=filled_depth_map_inpaint, ground_truth=ground_truth)
-plot_depth_map_from_img_dataframe(filled_depth_map_inpaint)
+patch_inpaint_method = PatchInpaintMethod(inpaint_radius=inpaint_radius)
+filled_depth_map_patch_inpaint = patch_inpaint_method.fill_holes(depth_map=sparse_map)
+patch_inpaint_method.calculate_metrics(depth_map=filled_depth_map_patch_inpaint, ground_truth=ground_truth)
+plot_depth_map_from_img_dataframe(filled_depth_map_patch_inpaint)
 
-interpolation_method.plot_metrics()
-inpainting_method.plot_metrics()
+# Filling through diffusion inpainting
+diffusion_inpaint_method = DiffusionInpaintMethod()
+filled_depth_map_diffusion_inpaint = diffusion_inpaint_method.fill_holes(depth_map=sparse_map)
+diffusion_inpaint_method.calculate_metrics(depth_map=filled_depth_map_diffusion_inpaint, ground_truth=ground_truth)
+plot_depth_map_from_img_dataframe(filled_depth_map_diffusion_inpaint)
+
+methods_studied = [interpolation_method, patch_inpaint_method, diffusion_inpaint_method]
+compare_methods_metrics(methods_studied)

--- a/manipulate_depthmap/hole_filling_methods/fill_depth_map_parent.py
+++ b/manipulate_depthmap/hole_filling_methods/fill_depth_map_parent.py
@@ -2,16 +2,20 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+import matplotlib.pyplot as plt
 
-from manipulate_depthmap.utilities.plottings import plot_radar_chart
+from manipulate_depthmap.utilities.auxiliar_methods import round_up_100
+from manipulate_depthmap.utilities.plotting_utilities.radar_chart_utilities import ComplexRadar
 
 
 class FillDepthMap:
     def __init__(self, name):
         self.name = name
-        self.mse = np.nan
-        self.rmse = np.nan
-        self.mae = np.nan
+        self.metrics = {
+            "mse": np.nan,
+            "rmse": np.nan,
+            "mae": np.nan,
+        }
 
     def fill_holes(self, depth_map):
         raise NotImplementedError("Method not implemented")
@@ -35,12 +39,23 @@ class FillDepthMap:
     def calculate_metrics(self, depth_map: Union[pd.DataFrame, np.ndarray], ground_truth: pd.DataFrame) -> None:
         depth_map = self.validate_input_depth_map(depth_map)
         ground_truth = ground_truth.values
-        self.mse = np.mean(np.square(ground_truth - depth_map))
-        self.rmse = np.sqrt(self.mse)
-        self.mae = np.mean(np.abs(ground_truth - depth_map))
+        self.metrics['mse'] = np.mean(np.square(ground_truth - depth_map))
+        self.metrics['rmse'] = np.sqrt(self.metrics['mse'])
+        self.metrics['mae'] = np.mean(np.abs(ground_truth - depth_map))
 
     def plot_metrics(self) -> None:
-        kpis = ["MSE (Mean square error)", "RMSE (Root mean square error)", "MAE (Mean absolute error)"]
-        scores = [self.mse, self.rmse, self.mae]
+        kpis = self.metrics.keys()
+        scores = list(self.metrics.values())
+
+        if np.any(np.isnan(scores)):
+            raise ValueError("Make sure that performance metrics have been calculated!")
+        
         method = self.name
-        plot_radar_chart(kpis, scores, method)
+        ranges = [(0, round_up_100(kpi_score)) for kpi_score in scores]     
+        fig = plt.figure(figsize=(6, 6))
+        radar = ComplexRadar(fig, kpis, ranges)
+        radar.plot(scores)
+        radar.fill(scores, alpha=0.2)
+        plt.legend(f"{method}")
+        plt.show()
+        

--- a/manipulate_depthmap/hole_filling_methods/inpaint_methods/diffusion_based.py
+++ b/manipulate_depthmap/hole_filling_methods/inpaint_methods/diffusion_based.py
@@ -1,0 +1,20 @@
+import numpy as np
+from skimage.restoration import inpaint
+import pandas as pd
+
+from manipulate_depthmap.hole_filling_methods.fill_depth_map_parent import \
+    FillDepthMap
+
+
+class DiffusionInpaintMethod(FillDepthMap):
+    def __init__(self):
+        super().__init__("diffuse_inpaint")
+
+    def fill_holes(self, depth_map: pd.DataFrame) -> np.ndarray:
+        depth_map = self.validate_input_depth_map(depth_map)
+        inpaint_mask = np.uint8(depth_map == 0)
+
+        depth_map = np.ascontiguousarray(depth_map)
+        inpaint_mask = np.ascontiguousarray(inpaint_mask)
+        filled_depth_map = inpaint.inpaint_biharmonic(depth_map, inpaint_mask)
+        return 255 * filled_depth_map

--- a/manipulate_depthmap/hole_filling_methods/inpaint_methods/patch_based.py
+++ b/manipulate_depthmap/hole_filling_methods/inpaint_methods/patch_based.py
@@ -6,10 +6,10 @@ from manipulate_depthmap.hole_filling_methods.fill_depth_map_parent import \
     FillDepthMap
 
 
-class InpaintingMethod(FillDepthMap):
+class PatchInpaintMethod(FillDepthMap):
     def __init__(self, inpaint_radius):
         self.inpaint_radius = inpaint_radius
-        super().__init__("inpainting")
+        super().__init__("patch_inpaint")
 
     def fill_holes(self, depth_map: pd.DataFrame) -> np.ndarray:
         depth_map = self.validate_input_depth_map(depth_map)

--- a/manipulate_depthmap/utilities/auxiliar_methods.py
+++ b/manipulate_depthmap/utilities/auxiliar_methods.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+
+def round_up_100(number):
+    return np.ceil(number / 100) * 100

--- a/manipulate_depthmap/utilities/plotting_utilities/radar_chart_utilities.py
+++ b/manipulate_depthmap/utilities/plotting_utilities/radar_chart_utilities.py
@@ -1,106 +1,168 @@
 import numpy as np
-
-
-def _invert(x, limits):
-    """inverts a value x on a scale from
-    limits[0] to limits[1]"""
-    return limits[1] - (x - limits[0])
-
-
-def _scale_data(data, ranges):
-    """scales data[1:] to ranges[0],
-    inverts if the scale is reversed"""
-    # for d, (y1, y2) in zip(data[1:], ranges[1:]):
-    for d, (y1, y2) in zip(data, ranges):
-        assert (y1 <= d <= y2) or (y2 <= d <= y1)
-
-    x1, x2 = ranges[0]
-    d = data[0]
-
-    if x1 > x2:
-        d = _invert(d, (x1, x2))
-        x1, x2 = x2, x1
-
-    sdata = [d]
-
-    for d, (y1, y2) in zip(data[1:], ranges[1:]):
-        if y1 > y2:
-            d = _invert(d, (y1, y2))
-            y1, y2 = y2, y1
-
-        sdata.append((d - y1) / (y2 - y1) * (x2 - x1) + x1)
-
-    return sdata
-
-
-def set_rgrids(self, radii, labels=None, angle=None, fmt=None,
-               **kwargs):
-    """
-    Set the radial locations and labels of the *r* grids.
-    The labels will appear at radial distances *radii* at the
-    given *angle* in degrees.
-    *labels*, if not None, is a ``len(radii)`` list of strings of the
-    labels to use at each radius.
-    If *labels* is None, the built-in formatter will be used.
-    Return value is a list of tuples (*line*, *label*), where
-    *line* is :class:`~matplotlib.lines.Line2D` instances and the
-    *label* is :class:`~matplotlib.text.Text` instances.
-    kwargs are optional text properties for the labels:
-    %(Text)s
-    ACCEPTS: sequence of floats
-    """
-    # Make sure we take into account unitized data
-    radii = self.convert_xunits(radii)
-    radii = np.asarray(radii)
-
-    self.set_yticks(radii)
-    if labels is not None:
-        self.set_yticklabels(labels)
-    elif fmt is not None:
-        self.yaxis.set_major_formatter(FormatStrFormatter(fmt))
-    if angle is None:
-        angle = self.get_rlabel_position()
-    self.set_rlabel_position(angle)
-    for t in self.yaxis.get_ticklabels():
-        t.update(kwargs)
-    return self.yaxis.get_gridlines(), self.yaxis.get_ticklabels()
+import textwrap
 
 
 class ComplexRadar():
-    def __init__(self, fig, variables, ranges,
-                 n_ordinate_levels=6):
-        angles = np.arange(0, 360, 360./len(variables))
+    """
+    Create a complex radar chart with different scales for each variable
+    Parameters
+    ----------
+    fig : figure object
+        A matplotlib figure object to add the axes on
+    variables : list
+        A list of variables
+    ranges : list
+        A list of tuples (min, max) for each variable
+    n_ring_levels: int, defaults to 5
+        Number of ordinate or ring levels to draw
+    show_scales: bool, defaults to True
+        Indicates if we the ranges for each variable are plotted
+    format_cfg: dict, defaults to None
+        A dictionary with formatting configurations
+    """
+    def __init__(self, fig, variables, ranges, n_ring_levels=5, show_scales=True, format_cfg=None):
+        
+        # Default formatting
+        self.format_cfg = {
+            # Axes
+            # https://matplotlib.org/stable/api/figure_api.html
+            'axes_args': {},
+            # Tick labels on the scales
+            # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.rgrids.html
+            'rgrid_tick_lbls_args': {'fontsize': 8},
+            # Radial (circle) lines
+            # https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.grid.html
+            'rad_ln_args': {},
+            # Angle lines
+            # https://matplotlib.org/3.2.2/api/_as_gen/matplotlib.lines.Line2D.html#matplotlib.lines.Line2D
+            'angle_ln_args': {},
+            # Include last value (endpoint) on scale
+            'incl_endpoint':False,
+            # Variable labels (ThetaTickLabel)
+            'theta_tick_lbls': {'va': 'top', 'ha': 'center'},
+            'theta_tick_lbls_txt_wrap': 15,
+            'theta_tick_lbls_brk_lng_wrds': False,
+            'theta_tick_lbls_pad': 25,
+            # Outer ring
+            # https://matplotlib.org/stable/api/spines_api.html
+            'outer_ring':{'visible':True, 'color':'#d6d6d6'}
+        }
+        
+        if format_cfg is not None:
+            self.format_cfg = {k: (format_cfg[k]) if k in format_cfg.keys() else (self.format_cfg[k]) 
+                 for k in self.format_cfg.keys()}        
+        
+        
+        # Calculate angles and create for each variable an axes
+        # Consider here the trick with having the first axes element twice (len+1)
+        angles = np.arange(0, 360, 360. / len(variables))
+        axes = [fig.add_axes([0.1, 0.1, 0.8, 0.8], 
+                             polar=True,
+                             label="axes{}".format(i),
+                             **self.format_cfg['axes_args']) for i in range(len(variables)+1)]
+        
+        # Ensure clockwise rotation (first variable at the top N)
+        for ax in axes:
+            ax.set_theta_zero_location('N')
+            ax.set_theta_direction(-1)
+            ax.set_axisbelow(True)
+        
+        # Writing the ranges on each axes
+        for i, ax in enumerate(axes):
 
-        axes = [fig.add_axes([0.1, 0.1, .8, .8], polar=True, label="axes{}".format(i)) for i in range(len(variables))]
-        l, text = axes[0].set_thetagrids(angles, labels=variables)
-        [txt.set_rotation(angle - 90) for txt, angle 
-             in zip(text, angles)]
+            # Here we do the trick by repeating the first iteration
+            j = 0 if (i == 0 or i ==1) else i - 1
+            ax.set_ylim(*ranges[j])
+            # Set endpoint to True if you like to have values right before the last circle
+            grid = np.linspace(*ranges[j], num=n_ring_levels, 
+                               endpoint=self.format_cfg['incl_endpoint'])
+            gridlabel = ["{}".format(round(x, 2)) for x in grid]
+            gridlabel[0] = ""  # remove values from the center
+            lines, labels = ax.set_rgrids(grid, 
+                                          labels=gridlabel, 
+                                          angle=angles[j],
+                                          **self.format_cfg['rgrid_tick_lbls_args']
+                                         )
+            
+            ax.set_ylim(*ranges[j])
+            ax.spines["polar"].set_visible(False)
+            ax.grid(visible=False)
+            
+            if not show_scales:
+                ax.set_yticklabels([])
 
+        # Set all axes except the first one unvisible
         for ax in axes[1:]:
             ax.patch.set_visible(False)
-            ax.grid("off")
             ax.xaxis.set_visible(False)
-
-        for i, ax in enumerate(axes):
-            grid = np.linspace(*ranges[i], 
-                               num=n_ordinate_levels)
-            gridlabel = ["{}".format(round(x,2)) 
-                         for x in grid]
-            if ranges[i][0] > ranges[i][1]:
-                grid = grid[::-1] # hack to invert grid
-                          # gridlabels aren't reversed
-            gridlabel[0] = "" # clean up origin
-            set_rgrids(ax, grid, labels=gridlabel, angle=angles[i])
-            ax.set_ylim(*ranges[i])
-        # variables for plotting
+            
+        # Setting the attributes
         self.angle = np.deg2rad(np.r_[angles, angles[0]])
         self.ranges = ranges
         self.ax = axes[0]
+        self.ax1 = axes[1]
+        self.plot_counter = 0
+        
+        
+        # Draw (inner) circles and lines
+        self.ax.yaxis.grid(**self.format_cfg['rad_ln_args'])
+        # Draw outer circle
+        self.ax.spines['polar'].set(**self.format_cfg['outer_ring'])
+        # Draw angle lines
+        self.ax.xaxis.grid(**self.format_cfg['angle_ln_args'])
 
-    def plot(self, data, *args, **kw):
-        sdata = _scale_data(data, self.ranges)
-        self.ax.plot(self.angle, np.r_[sdata, sdata[0]], *args, **kw)
+        # ax1 is the duplicate of axes[0] (self.ax)
+        # Remove everything from ax1 except the plot itself
+        self.ax1.axis('off')
+        self.ax1.set_zorder(9)
+        
+        # Create the outer labels for each variable
+        l, text = self.ax.set_thetagrids(angles, labels=variables)
+        
+        # Beautify them
+        labels = [t.get_text() for t in self.ax.get_xticklabels()]
+        labels = ['\n'.join(textwrap.wrap(l, self.format_cfg['theta_tick_lbls_txt_wrap'], 
+                                          break_long_words=self.format_cfg['theta_tick_lbls_brk_lng_wrds'])) for l in labels]
+        self.ax.set_xticklabels(labels, **self.format_cfg['theta_tick_lbls'])
+        
+        for t, a in zip(self.ax.get_xticklabels(), angles):
+            if a == 0:
+                t.set_ha('center')
+            elif a > 0 and a < 180:
+                t.set_ha('left')
+            elif a == 180:
+                t.set_ha('center')
+            else:
+                t.set_ha('right')
 
-    def fill(self, data, *args, **kw):
-        sdata = _scale_data(data, self.ranges)
-        self.ax.fill(self.angle, np.r_[sdata, sdata[0]], *args, **kw)
+        self.ax.tick_params(axis='both', pad=self.format_cfg['theta_tick_lbls_pad'])
+
+    def _scale_data(self, data, ranges):
+        """Scales data[1:] to ranges[0]"""
+        for d, (y1, y2) in zip(data[1:], ranges[1:]):
+            assert (y1 <= d <= y2) or (y2 <= d <= y1)
+        x1, x2 = ranges[0]
+        d = data[0]
+        sdata = [d]
+        for d, (y1, y2) in zip(data[1:], ranges[1:]):
+            sdata.append((d - y1) / (y2 - y1) * (x2 - x1) + x1)
+        return sdata
+        
+    def plot(self, data, *args, **kwargs):
+        """Plots a line"""
+        sdata = self._scale_data(data, self.ranges)
+        self.ax1.plot(self.angle, np.r_[sdata, sdata[0]], *args, **kwargs)
+        self.plot_counter = self.plot_counter + 1
+    
+    def fill(self, data, *args, **kwargs):
+        """Plots an area"""
+        sdata = self._scale_data(data, self.ranges)
+        self.ax1.fill(self.angle, np.r_[sdata, sdata[0]], *args, **kwargs)
+        
+    def use_legend(self, *args, **kwargs):
+        """Shows a legend"""
+        self.ax1.legend(*args, **kwargs)
+    
+    def set_title(self, title, pad=25, **kwargs):
+        """Set a title"""
+        self.ax.set_title(title, pad=pad, **kwargs)

--- a/manipulate_depthmap/utilities/plottings.py
+++ b/manipulate_depthmap/utilities/plottings.py
@@ -1,5 +1,15 @@
+import numpy as np
 import matplotlib.pyplot as plt
+from matplotlib import colors as mcolors
+from typing import List
+
+from manipulate_depthmap.utilities.auxiliar_methods import round_up_100
 from manipulate_depthmap.utilities.plotting_utilities.radar_chart_utilities import ComplexRadar
+from manipulate_depthmap.hole_filling_methods.fill_depth_map_parent import \
+    FillDepthMap
+
+
+colors = list(mcolors.TABLEAU_COLORS)
 
 
 def plot_depth_map_from_img_dataframe(img_dataframe):
@@ -12,7 +22,7 @@ def plot_both_sparse_and_ground_truth(img_dataframe, ground_truth_dataframe):
     pass
 
 
-def plot_radar_chart(labels, values, method):
+def plot_single_radar_chart(labels, values, method):
     # example data
     ranges = [(0, 7000), (0, 100), (0, 60)]            
     # plotting
@@ -20,5 +30,33 @@ def plot_radar_chart(labels, values, method):
     radar = ComplexRadar(fig1, labels, ranges)
     radar.plot(values)
     radar.fill(values, alpha=0.2)
-    plt.title(f"{method}")
+    plt.legend(f"{method}")
+    plt.show()
+
+
+def compare_methods_metrics(filled_depth_maps: List[FillDepthMap]):
+    values = np.vstack(list(filled_depth_map.metrics.values()) for filled_depth_map in filled_depth_maps)
+    # To define the axes ranges, pick up the biggest value of each column from values and round up it by a multiple of 100
+    ranges = [(0, round_up_100(score)) for score in np.max(values, axis=0)]
+
+    # All elements (methods) in a list share the same metrics. That is why we refer to the first one (it could be to any of them)
+    labels = filled_depth_maps[0].metrics.keys()
+
+    format_cfg = {
+        'rad_ln_args': {'visible': False},
+        'outer_ring': {'visible': False},
+        'rgrid_tick_lbls_args': {'fontsize': 6},
+        'theta_tick_lbls': {'fontsize': 9},
+        'theta_tick_lbls_pad': 5
+    }
+
+    fig = plt.figure(figsize=(6, 6), dpi=200)
+    radar = ComplexRadar(fig, labels, ranges, show_scales=True, format_cfg=format_cfg)
+
+    for idx, method in enumerate(filled_depth_maps):
+        scores = list(method.metrics.values())
+        radar.plot(scores, label=method.name, color=colors[idx])
+        radar.use_legend()
+
+    radar.set_title("XXX")
     plt.show()


### PR DESCRIPTION
- Create inpaint methods module to store all inpaint methods rather than storing them in 'inpainting_methods.py' module, which was removed.
- Remove method to plot radar chart from plottings.py, as it was redundant.
- Fix ComplexRadar class from radar_chart_utilities, which already works showing adequate results.
- Create auxiliar_methods.py module storing round_by_100 method, which is used to fix the boundaries of the radar chart plot.